### PR TITLE
whoami function

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -266,6 +266,12 @@ export function updateUserGroup({
   });
 }
 
+export function whoAmI({headers: propsHeaders}) {
+  const path = '/API/whoami';
+  const headers = {...propsHeaders, accept: 'text/plain'};
+  return vFetch({path, headers});
+}
+
 export function getToken({
   userName,
   queryParams,


### PR DESCRIPTION
Added the functionality to, with just headers for userName/alias and password, call the whoami endpoint in the API, returning a plain/text value containing the userName.